### PR TITLE
Fix incorrect INACTIVO badge detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,8 +41,12 @@ window.onload = () => {
 // === Utilitarios ===
 function estadoBadge(estadoRaw){
   const val = String(estadoRaw || "").trim().toUpperCase();
-  if (val.includes("ACTIVO") && !val.startsWith("IN-")) return `<span class="badge ok">ACTIVO</span>`;
-  if (val.startsWith("IN-")) return `<span class="badge bad">IN-ACTIVO</span>`;
+  if (val.startsWith("IN") && val.includes("ACTIVO")) {
+    return `<span class="badge bad">INACTIVO</span>`;
+  }
+  if (val.includes("ACTIVO")) {
+    return `<span class="badge ok">ACTIVO</span>`;
+  }
   return `<span class="badge warn">${estadoRaw ?? "SIN ESTADO"}</span>`;
 }
 


### PR DESCRIPTION
## Summary
- Correct inactive status detection in estadoBadge to avoid mislabeling `INACTIVO` as `ACTIVO`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68acb8e5e53c832e914cdb3216bcac3a